### PR TITLE
config dictionary path changes

### DIFF
--- a/vislab/_feature.py
+++ b/vislab/_feature.py
@@ -186,7 +186,7 @@ def extract_features(
         assert(mem >= RECOMMENDED_SETTINGS[feature_name]['mem'])
 
     # Determine the cache filename, thereby creating the right directory
-    dirname = vislab.util.makedirs('{}/{}'.format(vislab.config['feats'], dataset_name))
+    dirname = vislab.util.makedirs('{}/{}'.format(vislab.config['paths']['feats'], dataset_name))
     h5_filename = '{}/{}.h5'.format(dirname, feature_name)
 
     collection = get_feat_collection(feature_name)
@@ -260,7 +260,7 @@ def get_feat_collection(feature_name):
 
 
 def _cache_to_h5(dataset_name, image_ids, feat_name, force=False):
-    dirname = os.path.join(vislab.config['feats'], dataset_name)
+    dirname = os.path.join(vislab.config['paths']['feats'], dataset_name)
     if not os.path.exists(dirname):
         os.makedirs(dirname)
     filename = '{}/{}.h5'.format(dirname, feat_name)
@@ -321,7 +321,7 @@ def _cache_to_vw(dataset_name, image_ids, feature_name, force=False):
     If not, writes directly from database.
     """
     assert(feature_name in KNOWN_FEATURES)
-    dirname = os.path.join(vislab.config['feats'], dataset_name)
+    dirname = os.path.join(vislab.config['paths']['feats'], dataset_name)
     if not os.path.exists(dirname):
         os.makedirs(dirname)
     filename = '{}/{}.txt.gz'.format(dirname, feature_name)
@@ -330,7 +330,7 @@ def _cache_to_vw(dataset_name, image_ids, feature_name, force=False):
         return
 
     h5_filename = '{}/{}/{}.h5'.format(
-        vislab.config['feats'], dataset_name, feature_name)
+        vislab.config['paths']['feats'], dataset_name, feature_name)
 
     # If HDF5 cache exists, write from it, shuffling lines.
     if os.path.exists(h5_filename):
@@ -356,7 +356,7 @@ def _write_features_for_vw_from_h5(
     Does not standardize features, assumes already standardized.
     """
     h5_filename = '{}/{}/{}.h5'.format(
-        vislab.config['feats'], dataset_name, feature_name)
+        vislab.config['paths']['feats'], dataset_name, feature_name)
     try:
         df = pd.read_hdf(h5_filename, 'df')
     except:
@@ -409,7 +409,7 @@ def load_features_for_image_ids(image_ids, feature_name):
     df: pandas.DataFrame
     """
     assert(feature_name in KNOWN_FEATURES)
-    filename = '{}/{}.h5'.format(vislab.config['feats'], feature_name)
+    filename = '{}/{}.h5'.format(vislab.config['paths']['feats'], feature_name)
     with pandas.get_store(filename) as f:
         df = f['df']
         df = df.ix[image_ids].dropna()

--- a/vislab/dataset.py
+++ b/vislab/dataset.py
@@ -153,7 +153,7 @@ def get_df_with_args(args=None):
 
     elif args.dataset == 'behance_illustration':
         df = pd.read_csv(
-            vislab.config['behance_style_repo'] + '/data/10k_illustrations_20_tags_3_images.csv',
+            vislab.config['paths']['behance_style_repo'] + '/data/10k_illustrations_20_tags_3_images.csv',
             index_col=0)
 
     else:


### PR DESCRIPTION
a number of changed places referenced the `config` dictionary without including the `['paths']` attribute to correctly find things.

this change at least allows me to run noise features through the shell compute/predict commands we used when we met.
