### PR TITLE
better querying from mongo

### DIFF
--- a/ui/app.py
+++ b/ui/app.py
@@ -13,6 +13,7 @@ from tornado.httpserver import HTTPServer
 from tornado.ioloop import IOLoop
 import vislab.datasets
 import pymongo
+import numpy
 
 app = flask.Flask(__name__)
 style_names = vislab.datasets.flickr.underscored_style_names
@@ -23,15 +24,30 @@ def index():
         'data', dataset_name='pinterest', style_name='style_Pastel',
         pins_per_user=5, page=1)
     )
-
+def insert_dfs(db, collection):
+    print "Inserting df for {}".format(collection)
+    if collection == 'flickr_df':
+        df = vislab.datasets.flickr.get_df()
+    elif collection == 'pins_df':
+        df = vislab.datasets.pinterest.get_pins_80k_df()
+    for i in range(df.shape[0]):
+        d = df.iloc[i].to_dict()
+        for k, v in d.iteritems():
+            if type(d[k]) is numpy.bool_:
+                d[k] = bool(d[k])
+        db.insert(d)
 
 @app.route('/data/<dataset_name>/<style_name>/<int:pins_per_user>/<int:page>')
 def data(dataset_name, style_name, pins_per_user, page):
     client = pymongo.MongoClient('localhost', 27017)
     if dataset_name == 'flickr':
         db = client['ui_dfs']['flickr_df']
+        if db.count() == 0:
+            insert_dfs(db, 'flickr_df')
     elif dataset_name == 'pinterest':
         db = client['ui_dfs']['pins_df']
+        if db.count() == 0:
+            insert_dfs(db, 'pins_df')
     else:
         raise Exception("Unknown dataset")
 

--- a/ui/templates/data.html
+++ b/ui/templates/data.html
@@ -47,6 +47,7 @@
         {% endfor %}
     </select>
     {% endfor %}
+    <label>{{start_results}} to {{end_results}} of {{num_results}} results</label>
 </div>
 
 <div class="images">


### PR DESCRIPTION
It seems the best solution for pagination is to just take a slice from the cursor. This implicitly uses skip( ), which is supposed to be bad for performance. But if I were going to avoid using skip, the only solution is to find the object IDs corresponding to each page and that seems very unnecessary...
